### PR TITLE
Comment out 'Adding language fallback" message

### DIFF
--- a/src/dictionary_manager.cpp
+++ b/src/dictionary_manager.cpp
@@ -169,7 +169,7 @@ DictionaryManager::get_dictionary(const Language& language)
 
     if (!language.get_country().empty())
     {
-        printf("Adding language fallback %s\n", language.get_language().c_str());
+        // printf("Adding language fallback %s\n", language.get_language().c_str());
         dict->addFallback( &get_dictionary(Language::from_spec(language.get_language())) );
     }
     return *dict;


### PR DESCRIPTION
This shows up several times on SuperTux startup and seems to be a debugging leftover.