### PR TITLE
Improved collision logging

### DIFF
--- a/src/dictionary.cpp
+++ b/src/dictionary.cpp
@@ -193,7 +193,7 @@ Dictionary::add_translation(const std::string& msgctxt,
   {
     vec = msgstrs;
   }
-  else
+  else if (vec != msgstrs)
   {
     log_warning << "collision in add_translation(\"" << msgctxt << "\", \"" << msgid << "\", \"" << msgid_plural << "\")" << std::endl;
     vec = msgstrs;
@@ -208,7 +208,7 @@ Dictionary::add_translation(const std::string& msgctxt, const std::string& msgid
   {
     vec.push_back(msgstr);
   }
-  else
+  else if (vec[0] != msgstr)
   {
     log_warning << "collision in add_translation(\"" << msgctxt << "\", \"" << msgid << "\")" << std::endl;
     vec[0] = msgstr;

--- a/src/dictionary.cpp
+++ b/src/dictionary.cpp
@@ -170,12 +170,21 @@ Dictionary::translate_ctxt_plural(const std::string& msgctxt,
 }
 
 void
-Dictionary::add_translation(const std::string& msgid, const std::string& ,
+Dictionary::add_translation(const std::string& msgid, const std::string& msgid_plural,
                             const std::vector<std::string>& msgstrs)
 {
-  // Do we need msgid2 for anything? its after all supplied to the
-  // translate call, so we just throw it away here
-  entries[msgid] = msgstrs;
+  std::vector<std::string>& vec = entries[msgid];
+  if (vec.empty())
+  {
+    vec = msgstrs;
+  }
+  else if (vec != msgstrs)
+  {
+    log_warning << "collision in add_translation: '"
+                << msgid << "', '" << msgid_plural
+                << "' -> [" << vec << "] vs [" << msgstrs << "]" << std::endl;
+    vec = msgstrs;
+  }
 }
 
 void

--- a/src/dictionary.cpp
+++ b/src/dictionary.cpp
@@ -24,6 +24,17 @@
 
 namespace tinygettext {
 
+std::ostream& operator<<(std::ostream& o, const std::vector<std::string>& v)
+{
+  for (std::vector<std::string>::const_iterator it = v.begin(); it != v.end(); ++it)
+  {
+    if (it != v.begin())
+      o << ", ";
+    o << "'" << *it << "'";
+  }
+  return o;
+}
+
 Dictionary::Dictionary(const std::string& charset_) :
   entries(),
   ctxt_entries(),
@@ -195,7 +206,9 @@ Dictionary::add_translation(const std::string& msgctxt,
   }
   else if (vec != msgstrs)
   {
-    log_warning << "collision in add_translation(\"" << msgctxt << "\", \"" << msgid << "\", \"" << msgid_plural << "\")" << std::endl;
+    log_warning << "collision in add_translation: '"
+                << msgctxt << "', '" << msgid << "', '" << msgid_plural
+                << "' -> [" << vec << "] vs [" << msgstrs << "]" << std::endl;
     vec = msgstrs;
   }
 }
@@ -210,7 +223,9 @@ Dictionary::add_translation(const std::string& msgctxt, const std::string& msgid
   }
   else if (vec[0] != msgstr)
   {
-    log_warning << "collision in add_translation(\"" << msgctxt << "\", \"" << msgid << "\")" << std::endl;
+    log_warning << "collision in add_translation: '"
+                << msgctxt << "', '" << msgid
+                << "' -> '" << vec[0] << "' vs '" << msgstr << "'" << std::endl;
     vec[0] = msgstr;
   }
 }


### PR DESCRIPTION
Currently collisions for plural strings do not tell the user what actually conflicts, so first check if something actually conflicts and if yes log all plurals for the current and the new translation.