### PR TITLE
Disambiguate iconv calls to avoid compilation issues on BSD.

### DIFF
--- a/src/iconv.cpp
+++ b/src/iconv.cpp
@@ -47,14 +47,14 @@ IConv::IConv(const std::string& from_charset_, const std::string& to_charset_)
 IConv::~IConv()
 {
   if (cd)
-    iconv_close(cd);
+    tinygettext::iconv_close(cd);
 }
 
 void
 IConv::set_charsets(const std::string& from_charset_, const std::string& to_charset_)
 {
   if (cd)
-    iconv_close(cd);
+    tinygettext::iconv_close(cd);
 
   from_charset = from_charset_;
   to_charset   = to_charset_;
@@ -71,7 +71,7 @@ IConv::set_charsets(const std::string& from_charset_, const std::string& to_char
   }
   else
   {
-    cd = iconv_open(to_charset.c_str(), from_charset.c_str());
+    cd = tinygettext::iconv_open(to_charset.c_str(), from_charset.c_str());
     if (cd == reinterpret_cast<iconv_t>(-1))
     {
       if(errno == EINVAL)
@@ -111,12 +111,12 @@ IConv::convert(const std::string& text)
     char* outbuf = &result[0];
 
     // Try to convert the text.
-    size_t ret = iconv(cd, &inbuf, &inbytesleft, &outbuf, &outbytesleft);
+    size_t ret = tinygettext::iconv(cd, &inbuf, &inbytesleft, &outbuf, &outbytesleft);
     if (ret == static_cast<size_t>(-1))
     {
       if (errno == EILSEQ || errno == EINVAL)
       { // invalid multibyte sequence
-        iconv(cd, nullptr, nullptr, nullptr, nullptr); // reset state
+        tinygettext::iconv(cd, nullptr, nullptr, nullptr, nullptr); // reset state
 
         // FIXME: Could try to skip the invalid byte and continue
         log_error << "error: tinygettext:iconv: invalid multibyte sequence in:  \"" << text << "\"" << std::endl;


### PR DESCRIPTION
Based on a pull request on our game (https://github.com/abunchofhacks/Epicinium/pull/4):

> [DragonFly](https://man.dragonflybsd.org/?command=iconv&section=3), [FreeBSD](https://man.freebsd.org/iconv/3), [NetBSD](https://man.netbsd.org/iconv.3) (but not OpenBSD) have iconv* support from [Citrus Project](http://citrus.bsdclub.org/). What causes ambiguity is system `iconv_t` defined as a `struct` pointer instead a `void` pointer.

<details>
<summary>Clang error</summary>

```c++
$ c++ --version
FreeBSD clang version 11.0.0 (git@github.com:llvm/llvm-project.git llvmorg-11.0.0-0-g176249bd673)
Target: x86_64-unknown-freebsd13.0
Thread model: posix
InstalledDir: /usr/bin

$ CPATH=/usr/local/include gmake .obj/libs/tinygettext/iconv.o
c++ -std=c++17 -MT .obj/libs/tinygettext/iconv.o -MMD -MP -MF .dep/libs/tinygettext/iconv.Td -O3 -s -I ./ -I libs -I libs/SDL2 -o .obj/libs/tinygettext/iconv.o -c libs/tinygettext/iconv.cpp
libs/tinygettext/iconv.cpp:50:5: error: call to 'iconv_close' is ambiguous
    iconv_close(cd);
    ^~~~~~~~~~~
/usr/include/iconv.h:61:5: note: candidate function
int     iconv_close(iconv_t);
        ^
libs/tinygettext/iconv.hpp:69:12: note: candidate function
inline int iconv_close(iconv_t cd)
           ^
libs/tinygettext/iconv.cpp:57:5: error: call to 'iconv_close' is ambiguous
    iconv_close(cd);
    ^~~~~~~~~~~
/usr/include/iconv.h:61:5: note: candidate function
int     iconv_close(iconv_t);
        ^
libs/tinygettext/iconv.hpp:69:12: note: candidate function
inline int iconv_close(iconv_t cd)
           ^
libs/tinygettext/iconv.cpp:119:9: error: call to 'iconv' is ambiguous
        iconv(cd, nullptr, nullptr, nullptr, nullptr); // reset state
        ^~~~~
/usr/include/iconv.h:58:8: note: candidate function
size_t  iconv(iconv_t, char ** __restrict,
        ^
libs/tinygettext/iconv.hpp:58:15: note: candidate function
inline size_t iconv(iconv_t cd,
              ^
```
</details>

<details>
<summary>GCC error</summary>

```c++
$ g++11 --version
g++11 (FreeBSD Ports Collection) 11.0.0 20201108 (experimental)
Copyright (C) 2020 Free Software Foundation, Inc.
This is free software; see the source for copying conditions.  There is NO
warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.

$ CXX=g++11 gmake .obj/libs/tinygettext/iconv.o                                                               3& iconv γ /tmp/epicinium
g++11  -std=c++17 -MT .obj/libs/tinygettext/iconv.o -MMD -MP -MF .dep/libs/tinygettext/iconv.Td -O3 -s  -I ./  -I libs -I libs/SDL2 -o .obj/libs/tinygettext/iconv.o -c libs/tinygettext/iconv.cpp
libs/tinygettext/iconv.cpp: In destructor 'tinygettext::IConv::~IConv()':
libs/tinygettext/iconv.cpp:50:19: error: call of overloaded 'iconv_close(__tag_iconv_t*&)' is ambiguous
   50 |     iconv_close(cd);
      |                   ^
In file included from libs/tinygettext/iconv.cpp:28:
libs/tinygettext/iconv.hpp:69:12: note: candidate: 'int tinygettext::iconv_close(tinygettext::iconv_t)'
   69 | inline int iconv_close(iconv_t cd)
      |            ^~~~~~~~~~~
In file included from libs/tinygettext/iconv.hpp:28,
                 from libs/tinygettext/iconv.cpp:28:
/usr/include/iconv.h:61:9: note: candidate: 'int iconv_close(iconv_t)'
   61 | int     iconv_close(iconv_t);
      |         ^~~~~~~~~~~
libs/tinygettext/iconv.cpp: In member function 'void tinygettext::IConv::set_charsets(const string&, const string&)':
libs/tinygettext/iconv.cpp:57:19: error: call of overloaded 'iconv_close(__tag_iconv_t*&)' is ambiguous
   57 |     iconv_close(cd);
      |                   ^
In file included from libs/tinygettext/iconv.cpp:28:
libs/tinygettext/iconv.hpp:69:12: note: candidate: 'int tinygettext::iconv_close(tinygettext::iconv_t)'
   69 | inline int iconv_close(iconv_t cd)
      |            ^~~~~~~~~~~
In file included from libs/tinygettext/iconv.hpp:28,
                 from libs/tinygettext/iconv.cpp:28:
/usr/include/iconv.h:61:9: note: candidate: 'int iconv_close(iconv_t)'
   61 | int     iconv_close(iconv_t);
      |         ^~~~~~~~~~~
libs/tinygettext/iconv.cpp: In member function 'std::string tinygettext::IConv::convert(const string&)':
libs/tinygettext/iconv.cpp:119:53: error: call of overloaded 'iconv(__tag_iconv_t*&, std::nullptr_t, std::nullptr_t, std::nullptr_t, std::nullptr_t)' is ambiguous
  119 |         iconv(cd, nullptr, nullptr, nullptr, nullptr); // reset state
      |                                                     ^
In file included from libs/tinygettext/iconv.cpp:28:
libs/tinygettext/iconv.hpp:58:15: note: candidate: 'size_t tinygettext::iconv(tinygettext::iconv_t, const char**, size_t*, char**, size_t*)'
   58 | inline size_t iconv(iconv_t cd,
      |               ^~~~~
In file included from libs/tinygettext/iconv.hpp:28,
                 from libs/tinygettext/iconv.cpp:28:
/usr/include/iconv.h:58:9: note: candidate: 'size_t iconv(iconv_t, char**, size_t*, char**, size_t*)'
   58 | size_t  iconv(iconv_t, char ** __restrict,
      |         ^~~~~
```
</details>