### PR TITLE
Make tinygettext buildable with newer CMake versions

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,7 +18,7 @@
 #    misrepresented as being the original software.
 # 3. This notice may not be removed or altered from any source distribution.
 
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.10)
 
 include(mk/cmake/TinyCMMC.cmake)
 


### PR DESCRIPTION
The CMake folks seem to have decided that with newer versions of CMake the mimum requirement should be set to at least version 3.10 for it to build.